### PR TITLE
Build evcc from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 evcc-provisioning/evcc.yaml
 evcc-provisioning/dot-evcc
 .env
+.image_track_dir

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+TAG_NAME := 0.209.2-lurtz
+IMAGE_NAME := lurtz/evcc:$(TAG_NAME)
+TAG_FILE := .image_track_dir/$(TAG_NAME)
+export IMAGE_NAME
+
+# podman docker compatibility, might not be needed
+export BUILDAH_FORMAT=docker
+
 .PHONY: install-podman
 install-podman:
 	apt-get install -y podman-compose podman-docker
@@ -22,12 +30,24 @@ uninstall-service:
 	rm -f ~/.config/systemd/user/evcc-with-grafana.service
 	systemctl --user daemon-reload
 
+.image_track_dir:
+	mkdir -p .image_track_dir
+
+$(TAG_FILE): .image_track_dir
+	echo "Building $(IMAGE_NAME) image..." ; \
+	podman rmi --force localhost/$(IMAGE_NAME) || true
+	podman build --tag $(IMAGE_NAME) https://github.com/lurtz/evcc.git#$(TAG_NAME)
+	touch $(TAG_FILE)
+
+.PHONY: build
+build: $(TAG_FILE)
+
 .PHONY: up
-up:
+up: build
 	podman-compose up --pull --detach
 
 .PHONY: up-systemd
-up-systemd:
+up-systemd: build
 	podman-compose up --pull
 
 .PHONY: down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,9 @@ services:
     command:
       - evcc
     container_name: evcc
-    image: docker.io/evcc/evcc:0.209.0
+    image: $IMAGE_NAME
+    # Could have been the following, but https://github.com/containers/podman-compose/issues/127
+    # build: https://github.com/lurtz/evcc.git#0.209.2-lurtz
     ports:
       - 7070:7070/tcp
       - 8887:8887/tcp


### PR DESCRIPTION
This avoids having to push images to docker hub, which is now mostly automated. So the benefit of this pull request is questionable.