### PR TITLE
Calculate energy import and battery energy use

### DIFF
--- a/grafana-provisioning/dashboards/photovoltaik.json
+++ b/grafana-provisioning/dashboards/photovoltaik.json
@@ -296,7 +296,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "integrate(pvPower_value{id!~\".+\"}[24h] offset -1d) / 3600",
+          "expr": "(pvEnergy_value{id!~\".+\"} offset -1d - (pvEnergy_value{id!~\".+\"} offset 0d)) * 1000",
           "instant": false,
           "interval": "",
           "legendFormat": "PV",
@@ -344,7 +344,7 @@
             "uid": "P447A881CCE6EE299"
           },
           "editorMode": "code",
-          "expr": "integrate(-clamp_max(gridPower_value, 0)[24h]) / 3600",
+          "expr": "-(integrate(gridPower_value[24h] offset -1d) / 3600 - ((gridEnergy_value offset -1d - (gridEnergy_value offset 0d)) * 1000))",
           "legendFormat": "Einspeisung",
           "range": true,
           "refId": "F"
@@ -355,7 +355,7 @@
             "uid": "P447A881CCE6EE299"
           },
           "editorMode": "code",
-          "expr": "integrate(clamp_min(gridPower_value, 0)[24h]) / 3600",
+          "expr": "(gridEnergy_value offset -1d - (gridEnergy_value offset 0d)) * 1000",
           "legendFormat": "Bezug",
           "range": true,
           "refId": "E"
@@ -366,7 +366,7 @@
             "uid": "P447A881CCE6EE299"
           },
           "editorMode": "code",
-          "expr": "integrate(clamp_max(batteryPower_value{id!~\".+\"}, 0)[24h]) / 3600",
+          "expr": "-(integrate(batteryPower_value{id!~\".+\"}[24h] offset -1d) / 3600 - ((batteryEnergy_value{id!~\".+\"} offset -1d - batteryEnergy_value{id!~\".+\"} offset 0d) * 1000))",
           "legendFormat": "Batterie laden",
           "range": true,
           "refId": "H"
@@ -377,7 +377,7 @@
             "uid": "P447A881CCE6EE299"
           },
           "editorMode": "code",
-          "expr": "integrate(clamp_min(batteryPower_value{id!~\".+\"}, 0)[24h]) / 3600",
+          "expr": "(batteryEnergy_value{id!~\".+\"} offset -1d - batteryEnergy_value{id!~\".+\"} offset 0d) * 1000",
           "legendFormat": "Batterrie entladen",
           "range": true,
           "refId": "G"
@@ -1391,6 +1391,6 @@
   "timezone": "browser",
   "title": "Photovoltaik",
   "uid": "c0cf06af-fedf-49b3-af2b-a053381007b6",
-  "version": 30,
+  "version": 14,
   "weekStart": ""
 }


### PR DESCRIPTION
VmQL integrate() does not work with clamp(). However evcc stores exported energy in a separate time series, which allows us to avoid clamp().