### PR TITLE
Bump evcc to version 0.309.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     command:
       - evcc
     container_name: evcc
-    image: docker.io/ellutzor/evcc:0.306.3-lurtz
+    image: docker.io/ellutzor/evcc:0.309.1-lurtz
     ports:
       - 7070:7070/tcp
       - 8887:8887/tcp


### PR DESCRIPTION
It might get rid of the warning, that after restart the EM2GO Duo Power did not report power values.